### PR TITLE
provision container with micromamba, potentially to more reliably handle all Python script dependency needs

### DIFF
--- a/p3_hostile/build.package
+++ b/p3_hostile/build.package
@@ -68,7 +68,8 @@ unlink("$app_wrapper");
 open(P, ">", "$app_wrapper") or die "Cannot write $app_wrapper: $!";
 print P <<END;
 #!/bin/sh
-$dest/conda/bin/conda run mamba run -p $app_dest $app_name "\$@"
+export PATH=$app_dest/bin:\$PATH
+exec hostile "\$@"
 
 END
 

--- a/p3_hostile/environment.yml
+++ b/p3_hostile/environment.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - hostile=0.1.0
+  - hostile=1.1.0

--- a/p3_micromamba/build.package
+++ b/p3_micromamba/build.package
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+
+use strict;
+
+my $dest = $ENV{TARGET} || "/kb/runtime";
+
+if (@ARGV)
+{
+    $dest = shift;
+    print STDERR "Overriding destination to $dest\n";
+}
+my $runtime = $dest;
+if (@ARGV)
+{
+    $runtime = shift;
+}
+
+run("rm", "-rf", "$dest/micromamba");
+
+# See "Manual installation" under . . .
+# https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html
+run("curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar --directory $dest --strip-components=1  -xvj bin/micromamba");
+
+sub run
+{
+    print "@_\n";
+    my $rc = system(@_);
+    $rc == 0 or die "Command failed with rc=$rc: @_\n";
+}

--- a/p3_micromamba/build.package
+++ b/p3_micromamba/build.package
@@ -9,11 +9,6 @@ if (@ARGV)
     $dest = shift;
     print STDERR "Overriding destination to $dest\n";
 }
-my $runtime = $dest;
-if (@ARGV)
-{
-    $runtime = shift;
-}
 
 run("rm", "-rf", "$dest/micromamba");
 


### PR DESCRIPTION
micromamba (like mamba) is a drop-in replacement for the conda package manager.

conda is written in Python
"mamba is a reimplementation of the conda package manager in C++" (for speed, etc.)
"micromamba is a fully statically-linked, self-contained, executable"-version of mamba.
(which may avoid any OS-related lib compatibility issues . . . ever again)

I suspect any issues with needing a specific conda version, on the background of a given container host OS, maybe have arisen from conda being implemented in Python, itself. I'd guess it would be susceptible to any host Python dep/lib/version(s). As with many things with Python, it's shortcomings are often handled by re-implmentations of things/parts in a compiled language. :-)

I (like Dustin) like the pattern of using a conda environment, then pip-installing as necessary into that.
I'm thinking/wondering about a strategy like this:

Have a base conda env (manipulated by micromamba), with reasonable default common deps.
If a tool needs many special deps and/or versions of them, create a separate env for that tool.
If the space cost of having a lot of separate tool envs gets to be unacceptably high, try to stack them/some to save some space.
(https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#nested-activation)

Any env should have a minimal environment.yml file associated with it, with a python and top-level third-party deps (e.g. script import statements for things not in that Python version's stdlib) pinned to the minor version.

E.g.
```yaml
name: p3_some_app
channels:
  - conda-forge
dependencies:
  - python=3.11
  - pip
  - pip:
    - altair==5.2
    - ipython==8.18
    - matplotlib==3.8
    - numpy==1.26
    - openpyxl==3.1
    - pandas==2.1
    - pytest==7.4
    - pytest-cov==4.1
    - scipy==1.11
```

That way, both testers and wrapper tool developers could stay reproducible with the production container build.
Conda-packaged tools need not have any `- pip` section. Just make sure to pin it's conda dep minor version.
E.g. `- some_tool=1.0`

Apps can be installed, into their own env, like . . .
`micromamba env create --yes [--name override_env_name] --file environment.yml`

Python calls to a specific environment context might be handled something like this:
```bash
PYTHON="micromamba run --name p3_some_app python"
$PYTHON p3_some_app_cli_wrapper.py arg1 arg2 . . .
```
(. . . for example; use "run" for scripts, instead of "activating", as if interactive REPL dev)

What do you think about those ideas, @olsonanl ? -worth a pilot test? -maybe for the `hostile` tool?
I observed that, currently using the "run interactive mamba from interactive conda" pattern, takes a few seconds to start to just show the `hostile --version` info. And it displays the Mamba interactive welcome message, before running hostile.

Anyway, this installation alone should safely install micromamba and not interfere/interact with anything else.